### PR TITLE
PRTD-5250: MlFlow intergration into training pipeline & eval metrics expanded

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,8 @@ onnx>=1.10.0  # ONNX export
 onnx-simplifier>=0.3.6 # ONNX simplifier
 thop  # FLOPs computation
 # pytorch_quantization>=2.1.1
+mlflow>=2.17.2
+pynvml>=11.5.3
+torchinfo>=1.8.0
+psutil>=6.1.0
+boto3>=1.35.70

--- a/tools/train.py
+++ b/tools/train.py
@@ -59,6 +59,7 @@ def get_args_parser(add_help=True):
     parser.add_argument('--height', type=int, default=None, help='image height of model input')
     parser.add_argument('--width', type=int, default=None, help='image width of model input')
     parser.add_argument('--cache-ram', action='store_true', help='whether to cache images into RAM to speed up training')
+    parser.add_argument('--save-checkpoints-every-n-epoch', default=0, type=int, help='save checkpoints every n epoch')
 
     # mlflow args
     parser.add_argument('--mlflow-project-name', type=str, default='person_detector', help='mlflow project name')
@@ -66,12 +67,12 @@ def get_args_parser(add_help=True):
     parser.add_argument('--mlflow-run-name', type=str, default=f"person-detector-{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}", help='mlflow run name')
     parser.add_argument('--mlflow-run-description', type=str, default="Person detector training run", help='mlflow run description')
     parser.add_argument('--mlflow-model-registry-name', type=str, default="person_detector", help='mlflow model registry name')
-    parser.add_argument('--mlflow-tracking-uri', type=str, default=os.environ['MLFLOW_TRACKING_URI'], help='mlflow tracking uri')
-    parser.add_argument('--mlflow-tracking-username', type=str, default= os.environ['MLFLOW_TRACKING_USERNAME'], help='mlflow tracking username')
-    parser.add_argument('--mlflow-tracking-password', type=str, default=os.environ['MLFLOW_TRACKING_PASSWORD'], help='mlflow tracking password')
-    parser.add_argument('--mlflow-aws-access-key-id', type=str, default=os.environ['MLFLOW_AWS_ACCESS_KEY_ID'], help='mlflow aws access key id')
-    parser.add_argument('--mlflow-aws-secret-access-key', type=str, default=os.environ['MLFLOW_AWS_SECRET_ACCESS_KEY'], help='mlflow aws secret access key')
-    parser.add_argument('--mlflow-aws-default-region', type=str, default=os.environ['MLFLOW_AWS_DEFAULT_REGION'], help='mlflow aws default region')
+    parser.add_argument('--mlflow-tracking-uri', type=str, default=os.getenv('MLFLOW_TRACKING_URI'), help='mlflow tracking uri')
+    parser.add_argument('--mlflow-tracking-username', type=str, default= os.getenv('MLFLOW_TRACKING_USERNAME'), help='mlflow tracking username')
+    parser.add_argument('--mlflow-tracking-password', type=str, default=os.getenv('MLFLOW_TRACKING_PASSWORD'), help='mlflow tracking password')
+    parser.add_argument('--mlflow-aws-access-key-id', type=str, default=os.getenv('MLFLOW_AWS_ACCESS_KEY_ID'), help='mlflow aws access key id')
+    parser.add_argument('--mlflow-aws-secret-access-key', type=str, default=os.getenv('MLFLOW_AWS_SECRET_ACCESS_KEY'), help='mlflow aws secret access key')
+    parser.add_argument('--mlflow-aws-default-region', type=str, default=os.getenv('MLFLOW_AWS_DEFAULT_REGION'), help='mlflow aws default region')
 
     return parser
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -59,6 +59,20 @@ def get_args_parser(add_help=True):
     parser.add_argument('--height', type=int, default=None, help='image height of model input')
     parser.add_argument('--width', type=int, default=None, help='image width of model input')
     parser.add_argument('--cache-ram', action='store_true', help='whether to cache images into RAM to speed up training')
+
+    # mlflow args
+    parser.add_argument('--mlflow-project-name', type=str, default='person_detector', help='mlflow project name')
+    parser.add_argument('--mlflow-experiment-name', type=str, default=f"person-detector-{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}", help='mlflow experiment name')
+    parser.add_argument('--mlflow-run-name', type=str, default=f"person-detector-{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}", help='mlflow run name')
+    parser.add_argument('--mlflow-run-description', type=str, default="Person detector training run", help='mlflow run description')
+    parser.add_argument('--mlflow-model-registry-name', type=str, default="person_detector", help='mlflow model registry name')
+    parser.add_argument('--mlflow-tracking-uri', type=str, default=os.environ['MLFLOW_TRACKING_URI'], help='mlflow tracking uri')
+    parser.add_argument('--mlflow-tracking-username', type=str, default= os.environ['MLFLOW_TRACKING_USERNAME'], help='mlflow tracking username')
+    parser.add_argument('--mlflow-tracking-password', type=str, default=os.environ['MLFLOW_TRACKING_PASSWORD'], help='mlflow tracking password')
+    parser.add_argument('--mlflow-aws-access-key-id', type=str, default=os.environ['MLFLOW_AWS_ACCESS_KEY_ID'], help='mlflow aws access key id')
+    parser.add_argument('--mlflow-aws-secret-access-key', type=str, default=os.environ['MLFLOW_AWS_SECRET_ACCESS_KEY'], help='mlflow aws secret access key')
+    parser.add_argument('--mlflow-aws-default-region', type=str, default=os.environ['MLFLOW_AWS_DEFAULT_REGION'], help='mlflow aws default region')
+
     return parser
 
 

--- a/yolov6/core/evaler.py
+++ b/yolov6/core/evaler.py
@@ -317,8 +317,8 @@ class Evaler:
             model.float()  # for training
             if task != 'train':
                 LOGGER.info(f"Results saved to {self.save_dir}")
-            return (map50, map)
-        return (0.0, 0.0)
+            return cocoEval.stats
+        return tuple([0.0]*12) # cocoEval.stats has 12 value
 
     def eval_speed(self, task):
         '''Evaluate model inference speed.'''

--- a/yolov6/utils/checkpoint.py
+++ b/yolov6/utils/checkpoint.py
@@ -34,6 +34,7 @@ def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):
 
 def save_checkpoint(ckpt, is_best, save_dir, model_name=""):
     """ Save checkpoint to the disk."""
+    best_filename = None
     if not osp.exists(save_dir):
         os.makedirs(save_dir)
     filename = osp.join(save_dir, model_name + '.pt')
@@ -41,7 +42,7 @@ def save_checkpoint(ckpt, is_best, save_dir, model_name=""):
     if is_best:
         best_filename = osp.join(save_dir, 'best_ckpt.pt')
         shutil.copyfile(filename, best_filename)
-    return filename
+    return filename, best_filename
 
 
 def strip_optimizer(ckpt_dir, epoch):

--- a/yolov6/utils/checkpoint.py
+++ b/yolov6/utils/checkpoint.py
@@ -41,6 +41,7 @@ def save_checkpoint(ckpt, is_best, save_dir, model_name=""):
     if is_best:
         best_filename = osp.join(save_dir, 'best_ckpt.pt')
         shutil.copyfile(filename, best_filename)
+    return filename
 
 
 def strip_optimizer(ckpt_dir, epoch):

--- a/yolov6/utils/events.py
+++ b/yolov6/utils/events.py
@@ -32,8 +32,19 @@ def save_yaml(data_dict, save_path):
 
 def write_tblog(tblogger, epoch, results, lrs, losses):
     """Display mAP and loss information to log."""
-    tblogger.add_scalar("val/mAP@0.5", results[0], epoch + 1)
-    tblogger.add_scalar("val/mAP@0.50:0.95", results[1], epoch + 1)
+    
+    tblogger.add_scalar("val/mAP@0.50:0.95", results[0], epoch + 1)
+    tblogger.add_scalar("val/mAP@0.5", results[1], epoch + 1)
+    tblogger.add_scalar("val/mAP@0.75", results[2], epoch + 1)
+    tblogger.add_scalar("val/mAP@0.50:0.95_small", results[3], epoch + 1)
+    tblogger.add_scalar("val/mAP@0.50:0.95_medium", results[4], epoch + 1)
+    tblogger.add_scalar("val/mAP@0.50:0.95_large", results[5], epoch + 1)
+    tblogger.add_scalar("val/mAR@0.50:0.95:maxDets1", results[6], epoch + 1)
+    tblogger.add_scalar("val/mAR@0.50:0.95:maxDets10", results[7], epoch + 1)
+    tblogger.add_scalar("val/mAR@0.50:0.95:maxDets100", results[8], epoch + 1)
+    tblogger.add_scalar("val/mAR@0.50:0.95_small", results[9], epoch + 1)
+    tblogger.add_scalar("val/mAR@0.50:0.95_medium", results[10], epoch + 1)
+    tblogger.add_scalar("val/mAR@0.50:0.95_large", results[11], epoch + 1)
 
     tblogger.add_scalar("train/iou_loss", losses[0], epoch + 1)
     tblogger.add_scalar("train/dist_focalloss", losses[1], epoch + 1)


### PR DESCRIPTION
MlFlow integrated to training pipeline, now we are logging all metrics, models, checkpoints, configs and tensorboard files into MLflow
Eval Metrics expanded from just map50:95 and map50 to all 12 coco eval metrics, 
Also place mixing up issue fixed for order or  map50:95 and map50 in logs, tensorboards, codes.